### PR TITLE
Fix BinaryOperatorAggregate type stripping

### DIFF
--- a/libs/langgraph/langgraph/_internal/_future.py
+++ b/libs/langgraph/langgraph/_internal/_future.py
@@ -167,9 +167,8 @@ def _ensure_future(
         elif EAGER_NOT_SUPPORTED or lazy:
             return loop.create_task(coro_or_future, name=name, context=context)
         else:
-            return asyncio.eager_task_factory(
-                loop, coro_or_future, name=name, context=context
-            )
+            eager_factory = getattr(asyncio, "eager_task_factory")
+            return eager_factory(loop, coro_or_future, name=name, context=context)
     except RuntimeError:
         if not called_wrap_awaitable:
             coro_or_future.close()

--- a/libs/langgraph/langgraph/channels/binop.py
+++ b/libs/langgraph/langgraph/channels/binop.py
@@ -14,11 +14,10 @@ __all__ = ("BinaryOperatorAggregate",)
 # Adapted from typing_extensions
 def _strip_extras(t):  # type: ignore[no-untyped-def]
     """Strips Annotated, Required and NotRequired from a given type."""
-    if hasattr(t, "__origin__"):
-        return _strip_extras(t.__origin__)
     if hasattr(t, "__origin__") and t.__origin__ in (Required, NotRequired):
         return _strip_extras(t.__args__[0])
-
+    if hasattr(t, "__origin__"):
+        return _strip_extras(t.__origin__)
     return t
 
 
@@ -35,11 +34,11 @@ class BinaryOperatorAggregate(Generic[Value], BaseChannel[Value, Value, Value]):
     __slots__ = ("value", "operator")
 
     def __init__(self, typ: type[Value], operator: Callable[[Value, Value], Value]):
+        typ = _strip_extras(typ)
         super().__init__(typ)
         self.operator = operator
         # special forms from typing or collections.abc are not instantiable
         # so we need to replace them with their concrete counterparts
-        typ = _strip_extras(typ)
         if typ in (collections.abc.Sequence, collections.abc.MutableSequence):
             typ = list
         if typ in (collections.abc.Set, collections.abc.MutableSet):

--- a/libs/langgraph/tests/test_channels.py
+++ b/libs/langgraph/tests/test_channels.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import Union
 
 import pytest
+from typing_extensions import Required
 
 from langgraph._internal._typing import MISSING
 from langgraph.channels.binop import BinaryOperatorAggregate
@@ -88,3 +89,11 @@ def test_binop() -> None:
     checkpoint = channel.checkpoint()
     channel = BinaryOperatorAggregate(int, operator.add).from_checkpoint(checkpoint)
     assert channel.get() == 10
+
+
+def test_binop_required() -> None:
+    channel = BinaryOperatorAggregate(Required[int], operator.add).from_checkpoint(
+        MISSING
+    )
+    assert channel.ValueType is int
+    assert channel.get() == 0


### PR DESCRIPTION
## Summary
- ensure BinaryOperatorAggregate strips Required/NotRequired type hints before initialization
- exercise Required type in channel tests
- call `asyncio.eager_task_factory` via `getattr` to satisfy type checker

## Testing
- `make format`
- `make lint`
- `TEST=tests/test_channels.py make test`


------
https://chatgpt.com/codex/tasks/task_e_68c5597c1078832f8855bf2ea6268f2d